### PR TITLE
Add check for startup fail (Smart Test Resources)

### DIFF
--- a/backend-beeyond/src/test/java/at/htl/beeyond/integration/util/DatabaseResource.java
+++ b/backend-beeyond/src/test/java/at/htl/beeyond/integration/util/DatabaseResource.java
@@ -1,8 +1,11 @@
 package at.htl.beeyond.integration.util;
 
+import com.github.dockerjava.api.exception.InternalServerErrorException;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.PostgreSQLContainer;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
@@ -15,9 +18,17 @@ public class DatabaseResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        DATABASE.start();
+        DATABASE.setPortBindings(Collections.singletonList("5432:5432"));
 
-        String url = DATABASE.getHost() + ":" + DATABASE.getMappedPort(5432);
+        try {
+            DATABASE.start();
+        } catch (ContainerLaunchException ex) {
+            if(!ex.getMessage().contains("Container startup failed")) {
+                ex.printStackTrace();
+            }
+        }
+
+        String url = DATABASE.getHost() + ":5432";
         return Collections.singletonMap("beeyond.postgres.host", url);
     }
 


### PR DESCRIPTION
This tries to connect to the locally running server if an exception while starting the container occurs.